### PR TITLE
Show that GitHub Actions can detect a failed test

### DIFF
--- a/tests/testthat/temp_fail_test.R
+++ b/tests/testthat/temp_fail_test.R
@@ -1,0 +1,6 @@
+library(causens)
+library(testthat)
+
+test_that("Test temporary failed test to ensure that GitHub Actions can detect this", {
+  expect_false(is.function(simulate_data))
+})

--- a/tests/testthat/test_temp_fail.R
+++ b/tests/testthat/test_temp_fail.R
@@ -1,0 +1,6 @@
+library(causens)
+library(testthat)
+
+test_that("Test temporary failed test to ensure that GitHub Actions can detect this", {
+  expect_false(is.function(simulate_data))
+})


### PR DESCRIPTION
This PR has only illustrative purposes. Do not merge

I added a unit test that fails on purpose. Let's see if GitHub Actions catches it.

```{r}
test_that("Test temporary failed test to ensure that GitHub Actions can detect this", {
  expect_false(is.function(simulate_data))
})
```